### PR TITLE
when a user unloads the page, trigger performance event

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link href="examples/console.css" rel="stylesheet">
 </head>
 <body>
-  <video id="videojs-event-tracking-player" class="video-js vjs-default-skin" controls></video>
+  <video id="videojs-event-tracking-player" class="video-js vjs-default-skin" controls preload="auto"></video>
   <button type="button" id="load">load another source</button>
   <div id="console"></div>
   <ul>

--- a/src/tracking/performance.js
+++ b/src/tracking/performance.js
@@ -64,6 +64,13 @@ const PerformanceTracking = function(config) {
     reset();
   };
 
+  if (typeof(window.addEventListener) == 'function') {
+    window.addEventListener('beforeunload', triggerAndReset);
+    player.on('dispose', function() {
+      window.removeEventListener('beforeunload', triggerAndReset);
+    });
+  }
+
   player.on('loadstart', function() {
     if (totalDuration > 0) {
       trigger();

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -20,8 +20,8 @@ module.exports = function(config) {
     frameworks: ['qunit', 'detectBrowsers'],
     files: [
       'node_modules/video.js/dist/video-js.css',
-      
-      
+
+
       'node_modules/sinon/pkg/sinon.js',
       'node_modules/video.js/dist/video.js',
       'test/dist/bundle.js'


### PR DESCRIPTION
Adds event listener that will trigger before the user closes the browser. This should help with performance tracking accuracy.