### PR TITLE
Updating buffering tracking to reset when paused

### DIFF
--- a/src/tracking/performance.js
+++ b/src/tracking/performance.js
@@ -98,7 +98,7 @@ const PerformanceTracking = function(config) {
   });
   player.on('tracking:buffered', function(e, data) {
     ({ bufferCount } = data);
-    bufferDuration = bufferDuration + data.secondsToLoad;
+    bufferDuration = +(bufferDuration + data.secondsToLoad).toFixed(3);
   });
   player.on('tracking:firstplay', function(e, data) {
     initialLoadTime = data.secondsToLoad;


### PR DESCRIPTION
Resolving https://github.com/spodlecki/videojs-event-tracking/issues/4

During a buffer event it was possible a user pauses the video and avoid the timer reset.