### PR TITLE
Added bufferingConfig to include scrub events while computing buffering metrics

### DIFF
--- a/examples/base.js
+++ b/examples/base.js
@@ -28,7 +28,12 @@
   player.eventTracking({
     performance: function(data) {
       log('tracking:performance', data);
-    }
+    },
+    /*
+    // optional configuration to consider buffering while user is scrubbing on the video player.
+    bufferingConfig: {
+      includeScrub: true
+    }*/
   });
 
   player.on('tracking:firstplay', function(e, data) {

--- a/src/tracking/buffering.js
+++ b/src/tracking/buffering.js
@@ -3,6 +3,11 @@
  * @param    {Object} [options={}]
  *           An object of options left to the plugin author to define.
  *
+ *           Can contain the following optional configuration, passed during plugin initialization:
+ *           bufferingConfig.includeScrub => Boolean indicating whether buffering metrics
+ *           should be considered for computation while user is scrubbing on the video player.
+ *
+ *
  * Tracks when the video player is marked as buffering and waits until the player
  * has made some progress.
  *
@@ -40,7 +45,7 @@ const BufferTracking = function(config) {
   const onPause = () => {
     bufferStart = false;
 
-    if (this.scrubbing()) {
+    if (this.scrubbing() && !(config.bufferingConfig && config.bufferingConfig.includeScrub)) {
       scrubbing = true;
       timer = setTimeout(function() {
         scrubbing = false;


### PR DESCRIPTION
PR for the [issue](https://github.com/spodlecki/videojs-event-tracking/issues/9).

This issue adds a backwards compatible and optional configuration, to consider computation of buffering metrics when the user is scrubbing on the video player. 

The configuration can be set manually by the user while initializing the `eventTracking` plugin:
```javascript
player.eventTracking({
    bufferingConfig: {
      includeScrub: true
    }
```

Tested with/without the scrub config in both chrome and firefox. Buffering metrics are getting computed as per expected.

npm run test : SUCCESS