### PR TITLE
Add failsafe to get duration during `timeupdate`

### DIFF
--- a/src/tracking/percentile.js
+++ b/src/tracking/percentile.js
@@ -24,7 +24,7 @@ const PercentileTracking = function(config) {
   let first = false;
   let second = false;
   let third = false;
-  let duration = 0;
+  let duration = null;
   let pauseCount = 0;
   let seekCount = 0;
 
@@ -32,7 +32,7 @@ const PercentileTracking = function(config) {
     first = false;
     second = false;
     third = false;
-    duration = 0;
+    duration = null;
     pauseCount = 0;
     seekCount = 0;
   };
@@ -40,11 +40,26 @@ const PercentileTracking = function(config) {
   const incPause = () => pauseCount++;
   const incSeek = () => seekCount++;
 
+  const getDuration = function() {
+    duration = +player.duration().toFixed(0);
+    if (duration > 0) {
+      const quarter = (duration / 4).toFixed(0);
+
+      first = +quarter;
+      second = +quarter * 2;
+      third = +quarter * 3;
+    }
+  };
+
   player.on('dispose', reset);
   player.on('loadstart', reset);
   player.on('tracking:pause', incPause);
   player.on('tracking:seek', incSeek);
   player.on('timeupdate', function() {
+    if (duration === null) {
+      getDuration();
+    }
+
     const curTime = +player.currentTime().toFixed(0);
     const data = {
       seekCount,
@@ -80,16 +95,7 @@ const PercentileTracking = function(config) {
     player.trigger('tracking:fourth-quarter', data);
   });
 
-  player.on('durationchange', function() {
-    duration = +player.duration().toFixed(0);
-    if (duration > 0) {
-      const quarter = (duration / 4).toFixed(0);
-
-      first = +quarter;
-      second = +quarter * 2;
-      third = +quarter * 3;
-    }
-  });
+  player.on('durationchange', getDuration);
 };
 
 export default PercentileTracking;


### PR DESCRIPTION
We noticed that sometimes, unpredictably, the 25-50-75 percentile events would not fire. We could not figure out a reliable way to reproduce the error, but if you add a breakpoint around line 55 here:

https://github.com/spodlecki/videojs-event-tracking/blob/204dba2ac76da072cd6bf8745c5bb2d8658068e5/src/tracking/percentile.js#L47-L71

...and repeatedly refresh the page while trying to play a video.js player with these events bound, eventually, you may run into a situation where `duration` is equal to 0.

It seems that either the `durationchange` event never fired, or it fired before the watcher got bound. In either case, for whatever reason, the `durationchange` callback here:

https://github.com/spodlecki/videojs-event-tracking/blob/204dba2ac76da072cd6bf8745c5bb2d8658068e5/src/tracking/percentile.js#L83-L93

...never ran in those bugged-out instances, so the `first`, `second`, and `third` variables never got set.

(I'm guessing this could be a browser bug? We are using Chrome 92 on macOS.)

This pull request aims to fix that issue by adding an additional check for `duration` during the `timeupdate` event.

I confirmed that this fix works by adding a breakpoint on the `getDuration()` call inside `timeupdate`. By doing the same refresh-page-and-hit-play, I was able to confirm that the code at the breakpoint does occasionally get called (i.e. when it would have broken before), and the percentile events do fire as expected.